### PR TITLE
Added setting to remove added classes after animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The currently available global options are:
 $('.dummy').viewportChecker({
     classToAdd: 'visible', // Class to add to the elements when they are visible
     classToRemove: 'invisible', // Class to remove before adding 'classToAdd' to the elements
+    keepClassToAdd: true, // Remove added classes after animation or keep them
     offset: [100 OR 10%], // The offset of the elements (let them appear earlier or later). This can also be percentage based by adding a '%' at the end
     invertBottomOffset: true, // Add the offset as a negative number to the element's bottom
     repeat: false, // Add the possibility to remove the class if the elements are not visible
@@ -40,11 +41,12 @@ Besides the global options you can also add data-attributes to each individual e
 
 Available attributes are:
 ```code
-<div data-vp-add-class="random"></div>          >   classToAdd
-<div data-vp-remove-class="random"></div>       >	classToRemove
-<div data-vp-offset="[100 OR 10%]"></div>       >	offset
-<div data-vp-repeat="true"></div>               >	repeat
-<div data-vp-scrollHorizontal="false"></div>    >	scrollHorizontal
+<div data-vp-add-class="random"></div>          > classToAdd
+<div data-vp-remove-class="random"></div>       > classToRemove
+<div vp-keep-add-class="true|false"></div>      > kepp added classes or remove them after animation
+<div data-vp-offset="[100 OR 10%]"></div>       > offset
+<div data-vp-repeat="true"></div>               > repeat
+<div data-vp-scrollHorizontal="false"></div>    > scrollHorizontal
 ```
 
 Use case

--- a/src/jquery.viewportchecker.js
+++ b/src/jquery.viewportchecker.js
@@ -21,6 +21,7 @@
         var options = {
             classToAdd: 'visible',
             classToRemove : 'invisible',
+            keepClassToAdd: true,
             offset: 100,
             repeat: false,
             invertBottomOffset: true,
@@ -61,6 +62,8 @@
                     attrOptions.classToAdd = $obj.data('vp-add-class');
                 if ($obj.data('vp-remove-class'))
                     attrOptions.classToRemove = $obj.data('vp-remove-class');
+                if ($obj.data('vp-keep-add-class'))
+                    attrOptions.keepClassToAdd = $obj.data('vp-keep-add-class');
                 if ($obj.data('vp-offset'))
                     attrOptions.offset = $obj.data('vp-offset');
                 if ($obj.data('vp-repeat'))
@@ -75,7 +78,7 @@
                 $.extend(objOptions, attrOptions);
 
                 // If class already exists; quit
-                if ($obj.hasClass(objOptions.classToAdd) && !objOptions.repeat){
+                if ($obj.data('vp-animated') && !objOptions.repeat){
                     return;
                 }
 
@@ -88,7 +91,7 @@
                     elemEnd = (!objOptions.scrollHorizontal) ? elemStart + $obj.height() : elemStart + $obj.width();
 
                 if(objOptions.invertBottomOffset)
-                	elemEnd -= (objOptions.offset * 2);
+                    elemEnd -= (objOptions.offset * 2);
 
                 // Add class if in viewport
                 if ((elemStart < viewportEnd) && (elemEnd > viewportStart)){
@@ -101,12 +104,24 @@
                     // Do the callback function. Callback wil send the jQuery object as parameter
                     objOptions.callbackFunction($obj, "add");
 
+                    // Set element as already animated
+                    $obj.data('vp-animated', true);
+
+                    if (!objOptions.keepClassToAdd) {
+                        $obj.one('webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend', function () {
+                            $obj.removeClass(objOptions.classToAdd);
+                        });
+                    }
+
                 // Remove class if not in viewport and repeat is true
                 } else if ($obj.hasClass(objOptions.classToAdd) && (objOptions.repeat)){
                     $obj.removeClass(objOptions.classToAdd);
 
                     // Do the callback function.
                     objOptions.callbackFunction($obj, "remove");
+
+                    // Remove already-animated-flag
+                    $obj.data('vp-animated', false);
                 }
             });
 


### PR DESCRIPTION
If "keepClassToAdd" is set to false, the added classes will be removed after the animation has finished.

This is usefull if helper-classes (like with animate.css) are used, which can be safely removed after the animation has finished to clean up the DOM.
