### PR TITLE
Update to removeClassAfterAnimation condition bug

### DIFF
--- a/src/jquery.viewportchecker.js
+++ b/src/jquery.viewportchecker.js
@@ -119,7 +119,7 @@
                     // Set element as already animated
                     $obj.data('vp-animated', true);
 
-                    if (!objOptions.removeClassAfterAnimation) {
+                    if (objOptions.removeClassAfterAnimation) {
                         $obj.one('webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend', function(){
                             $obj.removeClass(objOptions.classToAdd);
                         });


### PR DESCRIPTION
@dirkgroenen I ran into an issue where `removeClassAfterAnimation: false` would still remove the `classToAdd` and this is what I did to fix it. 

Fixes #31 + #30 

/cc @cojocaru3 @Jessman5