### PR TITLE
Google Canary Version 61 - body.scrollTop() is returning 0

### DIFF
--- a/src/jquery.viewportchecker.js
+++ b/src/jquery.viewportchecker.js
@@ -34,7 +34,7 @@
         // Cache the given element and height of the browser
         var $elem = this,
             boxSize = {height: $(options.scrollBox).height(), width: $(options.scrollBox).width()},
-            scrollElem = ((navigator.userAgent.toLowerCase().indexOf('webkit') != -1 || navigator.userAgent.toLowerCase().indexOf('windows phone') != -1) ? 'body' : 'html');
+            scrollElem = ((navigator.userAgent.toLowerCase().indexOf('webkit') != -1 || navigator.userAgent.toLowerCase().indexOf('windows phone') != -1) ? 'html, body' : 'html');
 
         /*
          * Main method that checks the elements and adds or removes the class(es)

--- a/src/jquery.viewportchecker.js
+++ b/src/jquery.viewportchecker.js
@@ -34,8 +34,7 @@
         // Cache the given element and height of the browser
         var $elem = this,
             boxSize = {height: $(options.scrollBox).height(), width: $(options.scrollBox).width()},
-            scrollElem = ((navigator.userAgent.toLowerCase().indexOf('webkit') != -1 || navigator.userAgent.toLowerCase().indexOf('windows phone') != -1) ? 'html, body' : 'html');
-
+            scrollElem = $('html').scrollTop() ? 'html' : 'body'
         /*
          * Main method that checks the elements and adds or removes the class(es)
          */


### PR DESCRIPTION
View-port detection is wrong on current canary and the scroll isn't working only with ('body')