### PR TITLE
add check to stop trigger on not visible elements

### DIFF
--- a/src/jquery.viewportchecker.js
+++ b/src/jquery.viewportchecker.js
@@ -87,8 +87,10 @@
                 $.extend(objOptions, options);
                 $.extend(objOptions, attrOptions);
 
-                // If class already exists; quit
-                if ($obj.data('vp-animated') && !objOptions.repeat){
+                // If class already exists or obj is not visible ; quit
+                if (($obj.data('vp-animated') && !objOptions.repeat)
+                    || !$obj.is(':visible')
+                ) {
                     return;
                 }
 


### PR DESCRIPTION
Hello,
I had an issue on a page with multiple tabs and viewportChecker was trigger on all tabs, visible or not visible. I have attempt to fix it with some code out of lib but it seems not possible. I think this litlle fix can help other people ;-)